### PR TITLE
[Fixes #117] Refactor get_ functions to return {:error, :noun_not_found} errors in preperation for a blog article.

### DIFF
--- a/lib/franklin/articles.ex
+++ b/lib/franklin/articles.ex
@@ -39,21 +39,27 @@ defmodule Franklin.Articles do
   end
 
   @doc """
-  Returns the `Article` entity with an identity matching the given id or
-  `nil` if none is found.
+  Returns {:ok, %Article{}} when an article with the given identity can be found
+  and `{:error, :article_not_found}` if unsuccessful.
   """
-  @spec get_article(Ecto.UUID.t()) :: Article.t() | nil
-  def get_article(id) do
-    Repo.get(Article, id)
+  @spec fetch_article(Article.id()) :: {:ok, Article.t()} | {:error, :article_not_found}
+  def fetch_article(id) do
+    case Repo.get(Article, id) do
+      nil -> {:error, :article_not_found}
+      %Article{} = article -> {:ok, article}
+    end
   end
 
   @doc """
-  Returns the `Article` entity for the matching slug value or
-  `nil` if none is found.
+  Returns {:ok, %Article{}} when an article with the given slug value can be found
+  and `{:error, :article_not_found}` if unsuccessful.
   """
-  @spec get_article_by_slug(Ecto.UUID.t()) :: Article.t() | nil
-  def get_article_by_slug(slug) do
-    Repo.get_by(Article, slug: slug)
+  @spec fetch_article_by_slug(Article.slug()) :: {:ok, Article.t()} | {:error, :article_not_found}
+  def fetch_article_by_slug(slug) do
+    case Repo.get_by(Article, slug: slug) do
+      nil -> {:error, :article_not_found}
+      %Article{} = article -> {:ok, article}
+    end
   end
 
   @doc """

--- a/lib/franklin/articles/article.ex
+++ b/lib/franklin/articles/article.ex
@@ -7,11 +7,14 @@ defmodule Franklin.Articles.Article do
 
   use Ecto.Schema
 
+  @type id :: Ecto.UUID.t()
+  @type slug :: String.t()
+
   @type t :: %__MODULE__{
           body: String.t(),
-          id: Ecto.UUID.t(),
+          id: id(),
           published_at: DateTime.t(),
-          slug: String.t(),
+          slug: slug,
           title: String.t()
         }
 

--- a/lib/franklin_web/live/admin/articles/editor_live.ex
+++ b/lib/franklin_web/live/admin/articles/editor_live.ex
@@ -23,7 +23,14 @@ defmodule FranklinWeb.Admin.Articles.EditorLive do
 
   @spec assign_article(Socket.t(), map()) :: Socket.t()
   defp assign_article(socket, %{"id" => id}) do
-    assign(socket, article: Articles.get_article(id))
+    case Articles.fetch_article(id) do
+      {:ok, article} ->
+        assign(socket, article: article)
+
+      {:error, :article_not_found} ->
+        raise Ecto.NoResultsError
+        socket
+    end
   end
 
   defp assign_article(socket, _) do

--- a/lib/franklin_web/live/admin/articles/viewer_live.ex
+++ b/lib/franklin_web/live/admin/articles/viewer_live.ex
@@ -19,7 +19,14 @@ defmodule FranklinWeb.Admin.Articles.ViewerLive do
 
   @spec assign_article(Socket.t(), map()) :: Socket.t()
   defp assign_article(socket, %{"id" => id}) do
-    assign(socket, article: Articles.get_article(id))
+    case Articles.fetch_article(id) do
+      {:ok, article} ->
+        assign(socket, article: article)
+
+      {:error, :article_not_found} ->
+        raise Ecto.NoResultsError
+        socket
+    end
   end
 
   @spec assign_rendered_body(Socket.t()) :: Socket.t()

--- a/lib/franklin_web/live/articles/viewer_live.ex
+++ b/lib/franklin_web/live/articles/viewer_live.ex
@@ -20,13 +20,13 @@ defmodule FranklinWeb.Articles.ViewerLive do
   defp assign_article(socket, slug) do
     slug = Enum.join(slug, "/") |> Kernel.<>("/")
 
-    case Articles.get_article_by_slug(slug) do
-      nil ->
+    case Articles.fetch_article_by_slug(slug) do
+      {:ok, article} ->
+        assign(socket, article: article)
+
+      {:error, :article_not_found} ->
         raise Ecto.NoResultsError
         socket
-
-      article ->
-        assign(socket, article: article)
     end
   end
 

--- a/test/franklin_web/admin-user-stories/can_create_and_edit_with_article_editor_test.exs
+++ b/test/franklin_web/admin-user-stories/can_create_and_edit_with_article_editor_test.exs
@@ -27,15 +27,16 @@ defmodule FranklinWeb.AdminUserStories.CanCreateAndEditWithArticleEditor do
 
     {:ok, edit_article_id} = Articles.create_article(edit_article_attributes)
 
-    edit_article =
+    {:ok, edit_article} =
       wait_for_passing(fn ->
         # Because projections are not instant, we need to wait until it is finished.
-        assert %Article{
-                 title: "edit article title",
-                 slug: "slug/edit-article-title/",
-                 body: "edit article body",
-                 published_at: ^now
-               } = Articles.get_article(edit_article_id)
+        assert {:ok,
+                %Article{
+                  title: "edit article title",
+                  slug: "slug/edit-article-title/",
+                  body: "edit article body",
+                  published_at: ^now
+                }} = Articles.fetch_article(edit_article_id)
       end)
 
     conn = add_authentication(conn, "zorn", "Pass1234")
@@ -61,7 +62,7 @@ defmodule FranklinWeb.AdminUserStories.CanCreateAndEditWithArticleEditor do
     article =
       wait_for_passing(fn ->
         # FIXME: This is a shit test because I'm using `list_articles/0` but atm I don't
-        # have the `id` of the created article to use in `get_article/1`. Once we
+        # have the `id` of the created article to use in `fetch_article/1`. Once we
         # change to redirecting to a view page we can sniff the id from the url
         # being redirected to.
         assert Enum.find(Articles.list_articles(), nil, fn article ->
@@ -137,12 +138,13 @@ defmodule FranklinWeb.AdminUserStories.CanCreateAndEditWithArticleEditor do
 
     # Because the data projection can take time, we need to wait_for_passing.
     wait_for_passing(fn ->
-      assert %Article{
-               title: ^edited_title,
-               slug: ^edited_slug,
-               body: ^edited_body,
-               published_at: ^edited_published_at
-             } = Articles.get_article(edit_article.id)
+      assert {:ok,
+              %Article{
+                title: ^edited_title,
+                slug: ^edited_slug,
+                body: ^edited_body,
+                published_at: ^edited_published_at
+              }} = Articles.fetch_article(edit_article.id)
     end)
 
     redirect_path = "/admin/articles/#{edit_article.id}"

--- a/test/support/arrange_article_helpers.ex
+++ b/test/support/arrange_article_helpers.ex
@@ -18,7 +18,7 @@ defmodule Franklin.ArrangeArticleHelpers do
     {:ok, uuid} = Articles.create_article(attrs)
 
     wait_for_passing(fn ->
-      %Article{} = article = Articles.get_article(uuid)
+      {:ok, article} = Articles.fetch_article(uuid)
 
       for field <- Map.keys(attrs) do
         attr_value = Map.get(attrs, field)


### PR DESCRIPTION
Fixes #117 

Adding new `fetch_article/1` in favor of `get_noun/1` style, per our code style guide.

https://github.com/zorn/franklin/blob/986f95811cb7b35e2159f10e1cc4322dd09fccf3/guides/code_style/context_accessors.md?plain=1#L5-L11