### PR TITLE
[Fixes #97] We should reconsider how we use truncate for DateTime to make things more easy to reason about.

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -13,7 +13,7 @@ alias Franklin.Posts.Commands.DeletePost
 
 # Generate an ID for the post
 uuid = Ecto.UUID.generate()
-now = DateTime.utc_now() |> DateTime.truncate(:second)
+now = DateTime.utc_now()
 
 # Create a command instance
 command = %CreatePost{uuid: uuid, title: "Hello, world!", published_at: now}

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,7 +10,7 @@ import Config
 config :franklin,
   ecto_repos: [Franklin.Repo]
 
-config :franklin, Franklin.Repo, migration_timestamps: [type: :utc_datetime]
+config :franklin, Franklin.Repo, migration_timestamps: [type: :utc_datetime_usec]
 
 # Configures the endpoint
 config :franklin, FranklinWeb.Endpoint,

--- a/lib/franklin/articles/article.ex
+++ b/lib/franklin/articles/article.ex
@@ -22,11 +22,11 @@ defmodule Franklin.Articles.Article do
 
   schema "articles" do
     field :body, :string
-    field :published_at, :utc_datetime
+    field :published_at, :utc_datetime_usec
     field :slug, :string
     field :title, :string
 
-    timestamps(type: :utc_datetime)
+    timestamps(type: :utc_datetime_usec)
   end
 
   def insert_changeset(article, attrs \\ %{}) do

--- a/lib/franklin/articles/commands/create_article.ex
+++ b/lib/franklin/articles/commands/create_article.ex
@@ -22,7 +22,7 @@ defmodule Franklin.Articles.Commands.CreateArticle do
 
   embedded_schema do
     field :body, :string
-    field :published_at, :utc_datetime
+    field :published_at, :utc_datetime_usec
     field :slug, :string
     field :title, :string
   end

--- a/lib/franklin/articles/commands/update_article.ex
+++ b/lib/franklin/articles/commands/update_article.ex
@@ -22,7 +22,7 @@ defmodule Franklin.Articles.Commands.UpdateArticle do
 
   embedded_schema do
     field :body, :string
-    field :published_at, :utc_datetime
+    field :published_at, :utc_datetime_usec
     field :slug, :string
     field :title, :string
   end

--- a/lib/franklin/articles/events/article_created.ex
+++ b/lib/franklin/articles/events/article_created.ex
@@ -20,7 +20,6 @@ defimpl Commanded.Serialization.JsonDecoder, for: Franklin.Articles.Events.Artic
 
   def decode(%{published_at: published_at} = event) do
     {:ok, datetime, _} = DateTime.from_iso8601(published_at)
-    datetime = DateTime.truncate(datetime, :second)
     %{event | published_at: datetime}
   end
 end

--- a/lib/franklin/articles/events/article_published_at_updated.ex
+++ b/lib/franklin/articles/events/article_published_at_updated.ex
@@ -18,7 +18,6 @@ defimpl Commanded.Serialization.JsonDecoder,
 
   def decode(%{published_at: published_at} = event) do
     {:ok, datetime, _} = DateTime.from_iso8601(published_at)
-    datetime = DateTime.truncate(datetime, :second)
     %{event | published_at: datetime}
   end
 end

--- a/lib/franklin/posts/commands/create_post.ex
+++ b/lib/franklin/posts/commands/create_post.ex
@@ -23,7 +23,7 @@ defmodule Franklin.Posts.Commands.CreatePost do
   @primary_key {:id, Ecto.UUID, autogenerate: false}
 
   embedded_schema do
-    field :published_at, :utc_datetime
+    field :published_at, :utc_datetime_usec
     field :title, :string
   end
 

--- a/lib/franklin/posts/commands/update_post.ex
+++ b/lib/franklin/posts/commands/update_post.ex
@@ -37,7 +37,7 @@ defmodule Franklin.Posts.Commands.UpdatePost do
   @primary_key {:id, Ecto.UUID, autogenerate: false}
 
   embedded_schema do
-    field :published_at, :utc_datetime
+    field :published_at, :utc_datetime_usec
     field :title, :string
   end
 

--- a/lib/franklin/posts/events/post_created.ex
+++ b/lib/franklin/posts/events/post_created.ex
@@ -16,7 +16,6 @@ defimpl Commanded.Serialization.JsonDecoder, for: PostCreated do
   """
   def decode(%PostCreated{published_at: published_at} = event) do
     {:ok, datetime, _} = DateTime.from_iso8601(published_at)
-    datetime = DateTime.truncate(datetime, :second)
     %PostCreated{event | published_at: datetime}
   end
 end

--- a/lib/franklin/posts/events/post_published_at_updated.ex
+++ b/lib/franklin/posts/events/post_published_at_updated.ex
@@ -15,7 +15,6 @@ defimpl Commanded.Serialization.JsonDecoder, for: PostPublishedAtUpdated do
   """
   def decode(%PostPublishedAtUpdated{published_at: published_at} = event) do
     {:ok, datetime, _} = DateTime.from_iso8601(published_at)
-    datetime = DateTime.truncate(datetime, :second)
     %PostPublishedAtUpdated{event | published_at: datetime}
   end
 end

--- a/lib/franklin/posts/projections/post.ex
+++ b/lib/franklin/posts/projections/post.ex
@@ -12,9 +12,9 @@ defmodule Franklin.Posts.Projections.Post do
 
   schema "posts" do
     field :title, :string
-    field :published_at, :utc_datetime
+    field :published_at, :utc_datetime_usec
 
-    timestamps(type: :utc_datetime)
+    timestamps(type: :utc_datetime_usec)
   end
 
   def update_changeset(post, attrs \\ %{}) do

--- a/lib/franklin_web/live/admin/articles/article_form.ex
+++ b/lib/franklin_web/live/admin/articles/article_form.ex
@@ -21,7 +21,7 @@ defmodule FranklinWeb.Admin.Articles.ArticleForm do
 
   embedded_schema do
     field :body, :string
-    field :published_at, :utc_datetime
+    field :published_at, :utc_datetime_usec
     field :slug, :string
     field :slug_autogenerate, :boolean
     field :title, :string

--- a/lib/franklin_web/live/admin/articles/index_live.ex
+++ b/lib/franklin_web/live/admin/articles/index_live.ex
@@ -15,7 +15,7 @@ defmodule FranklinWeb.Admin.Articles.IndexLive do
     <h2 class="text-xl font-bold my-4">Articles</h2>
 
     <p class="my-4">
-      <.link href={~p"/admin/articles/new"}>New Article</.link>
+      <.link href={~p"/admin/articles/editor/new"}>New Article</.link>
     </p>
 
     <.admin_simple_table rows={@articles}>

--- a/lib/franklin_web/live/admin/post_editor_live/form.ex
+++ b/lib/franklin_web/live/admin/post_editor_live/form.ex
@@ -14,7 +14,7 @@ defmodule FranklinWeb.Admin.PostEditorLive.Form do
 
   embedded_schema do
     field :title, :string
-    field :published_at, :utc_datetime
+    field :published_at, :utc_datetime_usec
   end
 
   @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()

--- a/priv/repo/migrations/20220717191658_create_posts.exs
+++ b/priv/repo/migrations/20220717191658_create_posts.exs
@@ -5,8 +5,8 @@ defmodule Franklin.Repo.Migrations.CreatePosts do
     create table(:posts, primary_key: false) do
       add :id, :uuid, primary_key: true
       add :title, :string
-      add :published_at, :utc_datetime
-      timestamps(type: :utc_datetime)
+      add :published_at, :utc_datetime_usec
+      timestamps(type: :utc_datetime_usec)
     end
   end
 end

--- a/priv/repo/migrations/20221115214803_create_articles.exs
+++ b/priv/repo/migrations/20221115214803_create_articles.exs
@@ -7,8 +7,8 @@ defmodule Franklin.Repo.Migrations.CreateArticles do
       add :title, :string, null: false
       add :slug, :string, null: false
       add :body, :text, null: false
-      add :published_at, :utc_datetime, null: true
-      timestamps(type: :utc_datetime)
+      add :published_at, :utc_datetime_usec, null: true
+      timestamps(type: :utc_datetime_usec)
     end
 
     create unique_index(:articles, [:slug])

--- a/test/franklin/articles_test.exs
+++ b/test/franklin/articles_test.exs
@@ -71,12 +71,12 @@ defmodule Franklin.ArticlesTest do
     end
 
     test "can limit returned list and the default expected sort order is honored" do
-      create_article!(%{title: "January", published_at: ~U[2022-01-01 12:00:00Z]})
-      create_article!(%{title: "February", published_at: ~U[2022-02-01 12:00:00Z]})
-      create_article!(%{title: "March", published_at: ~U[2022-03-01 12:00:00Z]})
-      create_article!(%{title: "April", published_at: ~U[2022-04-01 12:00:00Z]})
-      create_article!(%{title: "May", published_at: ~U[2022-05-01 12:00:00Z]})
-      create_article!(%{title: "June", published_at: ~U[2022-06-01 12:00:00Z]})
+      create_article!(%{title: "January", published_at: ~U[2022-01-01 12:00:00.000000Z]})
+      create_article!(%{title: "February", published_at: ~U[2022-02-01 12:00:00.000000Z]})
+      create_article!(%{title: "March", published_at: ~U[2022-03-01 12:00:00.000000Z]})
+      create_article!(%{title: "April", published_at: ~U[2022-04-01 12:00:00.000000Z]})
+      create_article!(%{title: "May", published_at: ~U[2022-05-01 12:00:00.000000Z]})
+      create_article!(%{title: "June", published_at: ~U[2022-06-01 12:00:00.000000Z]})
 
       list = Articles.list_articles(%{limit: 3})
       assert length(list) == 3

--- a/test/franklin/posts_test.exs
+++ b/test/franklin/posts_test.exs
@@ -36,7 +36,7 @@ defmodule Franklin.PostsTest do
       assert %Post{
                id: ^uuid,
                title: "hello world",
-               published_at: ~U[2022-08-20 13:30:00Z]
+               published_at: ~U[2022-08-20 13:30:00.000000Z]
              } = Posts.get_post(uuid)
     end
 
@@ -52,7 +52,7 @@ defmodule Franklin.PostsTest do
     test "fails when title is too short", %{uuid: uuid} do
       attrs = %{
         id: uuid,
-        published_at: ~U[2022-08-20 13:30:00Z],
+        published_at: ~U[2022-08-20 13:30:00.000000Z],
         title: "hi"
       }
 
@@ -105,7 +105,7 @@ defmodule Franklin.PostsTest do
 
       assert %Post{
                id: ^uuid,
-               published_at: ~U[2019-08-20 13:30:00Z]
+               published_at: ~U[2019-08-20 13:30:00.000000Z]
              } = Posts.get_post(uuid)
     end
 
@@ -114,7 +114,7 @@ defmodule Franklin.PostsTest do
       assert {:ok, ^uuid} =
                Posts.update_post(test_post, %{
                  title: "new title",
-                 published_at: ~U[2019-08-20 13:30:00Z]
+                 published_at: ~U[2019-08-20 13:30:00.000000Z]
                })
 
       assert_receive {:post_title_updated, %{id: ^uuid}}
@@ -123,7 +123,7 @@ defmodule Franklin.PostsTest do
       assert %Post{
                id: ^uuid,
                title: "new title",
-               published_at: ~U[2019-08-20 13:30:00Z]
+               published_at: ~U[2019-08-20 13:30:00.000000Z]
              } = Posts.get_post(uuid)
     end
 
@@ -173,7 +173,7 @@ defmodule Franklin.PostsTest do
   defp valid_create_post_attrs(uuid) do
     %{
       id: uuid,
-      published_at: ~U[2022-08-20 13:30:00Z],
+      published_at: ~U[2022-08-20 13:30:00.000000Z],
       title: "hello world"
     }
   end

--- a/test/franklin_web/admin-user-stories/can_create_and_edit_with_article_editor_test.exs
+++ b/test/franklin_web/admin-user-stories/can_create_and_edit_with_article_editor_test.exs
@@ -15,7 +15,7 @@ defmodule FranklinWeb.AdminUserStories.CanCreateAndEditWithArticleEditor do
     # shape the tests to verify aspects of the form for both its create mode
     # as well as its edit version.
 
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    now = DateTime.utc_now()
 
     # This will be the article we will edit.
     edit_article_attributes = %{

--- a/test/franklin_web/admin-user-stories/can_nil_article_published_at_to_remove_from_public_test.exs
+++ b/test/franklin_web/admin-user-stories/can_nil_article_published_at_to_remove_from_public_test.exs
@@ -13,9 +13,9 @@ defmodule FranklinWeb.AdminUserStories.CanNilArticlePublishedAtToRemoveFromPubli
   test "previously public articles are no longer visible on public site after published_at value is set to nil",
        ~M{conn} do
     articles = [
-      create_article!(%{published_at: ~U[2023-01-10 00:01:00Z]}),
-      create_article!(%{published_at: ~U[2023-01-11 00:01:00Z]}),
-      create_article!(%{published_at: ~U[2023-01-12 00:01:00Z]})
+      create_article!(%{published_at: ~U[2023-01-10 00:01:00.000000Z]}),
+      create_article!(%{published_at: ~U[2023-01-11 00:01:00.000000Z]}),
+      create_article!(%{published_at: ~U[2023-01-12 00:01:00.000000Z]})
     ]
 
     edit_article = hd(articles)

--- a/test/franklin_web/admin-user-stories/can_visit_article_viewer_test.exs
+++ b/test/franklin_web/admin-user-stories/can_visit_article_viewer_test.exs
@@ -17,7 +17,7 @@ defmodule FranklinWeb.AdminUserStories.CanVisitArticleViewerTest do
     With a [link](http://example.com)!
     """
 
-    published_at = DateTime.utc_now() |> DateTime.truncate(:second)
+    published_at = DateTime.utc_now()
 
     article = create_article!(%{title: title, body: body, published_at: published_at})
     {:ok, view, _html} = live(conn, "/admin/articles/#{article.id}")

--- a/test/franklin_web/public-user-stories/can_download_rss_feed_test.exs
+++ b/test/franklin_web/public-user-stories/can_download_rss_feed_test.exs
@@ -12,17 +12,17 @@ defmodule FranklinWeb.PublicUserStories.CanDownloadRssFeedTest do
   setup %{conn: conn} do
     article1 =
       create_article!(%{
-        published_at: DateTime.add(DateTime.utc_now(), -1, :day) |> DateTime.truncate(:second)
+        published_at: DateTime.add(DateTime.utc_now(), -1, :day)
       })
 
     article2 =
       create_article!(%{
-        published_at: DateTime.add(DateTime.utc_now(), -2, :day) |> DateTime.truncate(:second)
+        published_at: DateTime.add(DateTime.utc_now(), -2, :day)
       })
 
     article3 =
       create_article!(%{
-        published_at: DateTime.add(DateTime.utc_now(), -3, :day) |> DateTime.truncate(:second)
+        published_at: DateTime.add(DateTime.utc_now(), -3, :day)
       })
 
     ~M{conn, article1, article2, article3}

--- a/test/franklin_web/public-user-stories/can_view_article_archive_list_test.exs
+++ b/test/franklin_web/public-user-stories/can_view_article_archive_list_test.exs
@@ -10,7 +10,7 @@ defmodule FranklinWeb.PublicUserStories.CanViewArticleArchiveListTest do
     articles =
       -1..-10
       |> Enum.map(fn n ->
-        published_at = DateTime.add(DateTime.utc_now(), n, :day) |> DateTime.truncate(:second)
+        published_at = DateTime.add(DateTime.utc_now(), n, :day)
         create_article!(~M{published_at})
       end)
 

--- a/test/franklin_web/public-user-stories/can_visit_article_viewer_test.exs
+++ b/test/franklin_web/public-user-stories/can_visit_article_viewer_test.exs
@@ -15,7 +15,7 @@ defmodule FranklinWeb.PublicUserStories.CanVisitArticleViewerTest do
     With a [link](http://example.com)!
     """
 
-    published_at = DateTime.utc_now() |> DateTime.truncate(:second)
+    published_at = DateTime.utc_now()
 
     article = create_article!(~M{title, body, published_at})
     {:ok, view, _html} = live(conn, "/articles/#{article.slug}")

--- a/test/support/arrange_article_helpers.ex
+++ b/test/support/arrange_article_helpers.ex
@@ -30,7 +30,7 @@ defmodule Franklin.ArrangeArticleHelpers do
   end
 
   defp required_new_article_attributes(custom_values) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    now = DateTime.utc_now()
 
     sample_markdown = """
     # This is a sample article headline


### PR DESCRIPTION
Fixes #97