### PR TITLE
[Fixes #235] Add a graph API endpoint to create articles.

### DIFF
--- a/lib/franklin/validation_error_map.ex
+++ b/lib/franklin/validation_error_map.ex
@@ -8,7 +8,7 @@ defmodule Franklin.ValidationErrorMap do
   ## Example:
 
       iex> new(changeset)
-      %Franklin.ValidationErrorMap{
+      %{
         id: ["is invalid"],
         published_at: ["can't be blank"],
         title: ["should be at least 3 character(s)"]

--- a/lib/franklin_web/resolvers/content.ex
+++ b/lib/franklin_web/resolvers/content.ex
@@ -1,5 +1,11 @@
 defmodule FranklinWeb.Resolvers.Content do
+  alias Franklin.Articles
+
   def list_articles(_parent, _args, _resolution) do
-    {:ok, Franklin.Articles.list_articles(%{published_only: true})}
+    {:ok, Articles.list_articles(%{published_only: true})}
+  end
+
+  def find_article(_parent, %{id: id}, _resolution) do
+    Articles.fetch_article(id)
   end
 end

--- a/lib/franklin_web/resolvers/content.ex
+++ b/lib/franklin_web/resolvers/content.ex
@@ -8,4 +8,11 @@ defmodule FranklinWeb.Resolvers.Content do
   def find_article(_parent, %{id: id}, _resolution) do
     Articles.fetch_article(id)
   end
+
+  def generate_upload_url(_parent, %{filename: filename}, _resolution) do
+    case Franklin.S3Storage.generate_presigned_url(filename) do
+      {:ok, url} -> {:ok, %{url: url}}
+      {:error, _} -> {:error, "Could not generate presigned url."}
+    end
+  end
 end

--- a/lib/franklin_web/resolvers/content.ex
+++ b/lib/franklin_web/resolvers/content.ex
@@ -15,4 +15,25 @@ defmodule FranklinWeb.Resolvers.Content do
       {:error, _} -> {:error, "Could not generate presigned url."}
     end
   end
+
+  def create_article(_parent, %{input: input}, _resolution) do
+    input
+    |> Articles.create_article()
+    |> format_payload()
+  end
+
+  defp format_payload({:ok, article_id}) do
+    {:ok, %{article_id: article_id}}
+  end
+
+  defp format_payload({:error, validation_error_map}) do
+    validation_error_map = stringify_keys(validation_error_map)
+    {:error, message: "A database error occurred", details: validation_error_map}
+  end
+
+  defp stringify_keys(map) do
+    Enum.reduce(map, %{}, fn {key, value}, acc ->
+      Map.put(acc, to_string(key), value)
+    end)
+  end
 end

--- a/lib/franklin_web/resolvers/content.ex
+++ b/lib/franklin_web/resolvers/content.ex
@@ -5,7 +5,7 @@ defmodule FranklinWeb.Resolvers.Content do
     {:ok, Articles.list_articles()}
   end
 
-  def find_article(_parent, %{id: id}, _resolution) do
+  def fetch_article(_parent, %{id: id}, _resolution) do
     Articles.fetch_article(id)
   end
 

--- a/lib/franklin_web/resolvers/content.ex
+++ b/lib/franklin_web/resolvers/content.ex
@@ -2,7 +2,7 @@ defmodule FranklinWeb.Resolvers.Content do
   alias Franklin.Articles
 
   def list_articles(_parent, _args, _resolution) do
-    {:ok, Articles.list_articles(%{published_only: true})}
+    {:ok, Articles.list_articles()}
   end
 
   def find_article(_parent, %{id: id}, _resolution) do

--- a/lib/franklin_web/schema.ex
+++ b/lib/franklin_web/schema.ex
@@ -14,7 +14,7 @@ defmodule FranklinWeb.Schema do
     @desc "Get an article by its id value."
     field :article, :article do
       arg(:id, :id)
-      resolve(&Resolvers.Content.find_article/3)
+      resolve(&Resolvers.Content.fetch_article/3)
     end
   end
 

--- a/lib/franklin_web/schema.ex
+++ b/lib/franklin_web/schema.ex
@@ -1,5 +1,6 @@
 defmodule FranklinWeb.Schema do
   use Absinthe.Schema
+  import_types(Absinthe.Type.Custom)
   import_types(FranklinWeb.Schema.ContentTypes)
 
   alias FranklinWeb.Resolvers
@@ -8,6 +9,12 @@ defmodule FranklinWeb.Schema do
     @desc "Get a list of the articles."
     field :articles, list_of(:article) do
       resolve(&Resolvers.Content.list_articles/3)
+    end
+
+    @desc "Get an article by its id value."
+    field :article, :article do
+      arg(:id, :id)
+      resolve(&Resolvers.Content.find_article/3)
     end
   end
 end

--- a/lib/franklin_web/schema.ex
+++ b/lib/franklin_web/schema.ex
@@ -17,4 +17,12 @@ defmodule FranklinWeb.Schema do
       resolve(&Resolvers.Content.find_article/3)
     end
   end
+
+  mutation do
+    @desc "Generate a presigned url for uploading a file to S3."
+    field :generate_upload_url, :upload_url do
+      arg(:filename, non_null(:string))
+      resolve(&Resolvers.Content.generate_upload_url/3)
+    end
+  end
 end

--- a/lib/franklin_web/schema.ex
+++ b/lib/franklin_web/schema.ex
@@ -24,5 +24,31 @@ defmodule FranklinWeb.Schema do
       arg(:filename, non_null(:string))
       resolve(&Resolvers.Content.generate_upload_url/3)
     end
+
+    @desc "Create a new article."
+    field :create_article, :create_article_payload do
+      arg(:input, non_null(:create_article_input))
+
+      resolve(&Resolvers.Content.create_article/3)
+    end
+  end
+
+  input_object :create_article_input do
+    field(:id, :id)
+    field(:title, non_null(:string))
+    field(:body, non_null(:string))
+    field(:slug, non_null(:string))
+    field(:published_at, :datetime)
+  end
+
+  object :create_article_payload do
+    field(:article_id, :id)
+    field(:errors, list_of(:input_error))
+  end
+
+  @desc "An error encountered trying to persist input"
+  object :input_error do
+    field(:details, non_null(:string))
+    field(:message, non_null(:string))
   end
 end

--- a/lib/franklin_web/schema/content_types.ex
+++ b/lib/franklin_web/schema/content_types.ex
@@ -5,5 +5,7 @@ defmodule FranklinWeb.Schema.ContentTypes do
     field :id, :id
     field :title, :string
     field :body, :string
+    field :slug, :string
+    field :published_at, :datetime
   end
 end

--- a/lib/franklin_web/schema/content_types.ex
+++ b/lib/franklin_web/schema/content_types.ex
@@ -8,4 +8,8 @@ defmodule FranklinWeb.Schema.ContentTypes do
     field :slug, :string
     field :published_at, :datetime
   end
+
+  object :upload_url do
+    field :url, :string
+  end
 end

--- a/test/franklin_web/api-experiences/can_create_article_test.exs
+++ b/test/franklin_web/api-experiences/can_create_article_test.exs
@@ -1,0 +1,80 @@
+defmodule FranklinWeb.ApiExperiences.CanCreateArticleTest do
+  use FranklinWeb.ConnCase
+
+  setup %{conn: conn} do
+    %{
+      title: title,
+      body: body,
+      published_at: published_at,
+      slug: slug
+    } = required_new_article_attributes()
+
+    ~M{conn, title, body, published_at, slug}
+  end
+
+  @query """
+  mutation CreateArticle($title: String!, $body: String!, $slug: String!, $publishedAt: DateTime) {
+    createArticle(input: {title: $title, body: $body, slug: $slug, publishedAt: $publishedAt}) {
+      article_id
+    }
+  }
+  """
+  test "can create an article with valid attributes",
+       ~M{conn, title, body, published_at, slug} do
+    conn =
+      post(conn, "/api",
+        query: @query,
+        variables: %{
+          title: title,
+          body: body,
+          slug: slug,
+          publishedAt: DateTime.to_iso8601(published_at)
+        }
+      )
+
+    assert response = json_response(conn, 200)
+
+    assert %{
+             "data" => %{
+               "createArticle" => %{
+                 "article_id" => id
+               }
+             }
+           } = response
+
+    assert {:ok, _uuid} = Ecto.UUID.cast(id)
+  end
+
+  test "returns error message when trying to create an article with invalid attributes",
+       ~M{conn, _title, body, published_at, _slug} do
+    conn =
+      post(conn, "/api",
+        query: @query,
+        variables: %{
+          title: "",
+          body: body,
+          slug: "",
+          publishedAt: DateTime.to_iso8601(published_at)
+        }
+      )
+
+    assert response = json_response(conn, 200)
+
+    assert %{
+             "data" => %{
+               "createArticle" => nil
+             },
+             "errors" => [
+               %{
+                 "details" => %{
+                   "title" => ["can't be blank"],
+                   "slug" => ["can't be blank"]
+                 },
+                 "locations" => _,
+                 "message" => "A database error occurred",
+                 "path" => ["createArticle"]
+               }
+             ]
+           } = response
+  end
+end

--- a/test/franklin_web/api-experiences/can_get_article_test.exs
+++ b/test/franklin_web/api-experiences/can_get_article_test.exs
@@ -47,6 +47,4 @@ defmodule FranklinWeb.ApiExperiences.CanGetArticleTest do
              ]
            }
   end
-
-  # SOMEDAY MAYBE: Add test for non uuid looking string "not-a-uuid".
 end

--- a/test/franklin_web/api-experiences/can_get_article_test.exs
+++ b/test/franklin_web/api-experiences/can_get_article_test.exs
@@ -1,0 +1,52 @@
+defmodule FranklinWeb.ApiExperiences.CanGetArticleTest do
+  use FranklinWeb.ConnCase
+
+  setup %{conn: conn} do
+    published_article = create_article!(%{published_at: DateTime.utc_now()})
+    ~M{conn, published_article}
+  end
+
+  @query """
+  query Article($id: ID!) {
+    article(id: $id) {
+      id
+      title
+      body
+      slug
+      publishedAt
+    }
+  }
+  """
+  test "returns an article by id", ~M{conn, published_article} do
+    conn = get(conn, "/api", query: @query, variables: %{id: published_article.id})
+
+    assert json_response(conn, 200) == %{
+             "data" => %{
+               "article" => %{
+                 "id" => published_article.id,
+                 "title" => published_article.title,
+                 "body" => published_article.body,
+                 "slug" => published_article.slug,
+                 "publishedAt" => DateTime.to_iso8601(published_article.published_at)
+               }
+             }
+           }
+  end
+
+  test "returns not found error message when no article with the given id exists", ~M{conn} do
+    conn = get(conn, "/api", query: @query, variables: %{id: Ecto.UUID.generate()})
+
+    assert json_response(conn, 200) == %{
+             "data" => %{"article" => nil},
+             "errors" => [
+               %{
+                 "message" => "article_not_found",
+                 "locations" => [%{"column" => 3, "line" => 2}],
+                 "path" => ["article"]
+               }
+             ]
+           }
+  end
+
+  # SOMEDAY MAYBE: Add test for non uuid looking string "not-a-uuid".
+end

--- a/test/franklin_web/api-experiences/can_get_article_test.exs
+++ b/test/franklin_web/api-experiences/can_get_article_test.exs
@@ -3,7 +3,8 @@ defmodule FranklinWeb.ApiExperiences.CanGetArticleTest do
 
   setup %{conn: conn} do
     published_article = create_article!(%{published_at: DateTime.utc_now()})
-    ~M{conn, published_article}
+    unpublished_article = create_article!(%{published_at: nil})
+    ~M{conn, published_article, unpublished_article}
   end
 
   @query """
@@ -17,7 +18,7 @@ defmodule FranklinWeb.ApiExperiences.CanGetArticleTest do
     }
   }
   """
-  test "returns an article by id", ~M{conn, published_article} do
+  test "returns an published article by id", ~M{conn, published_article} do
     conn = get(conn, "/api", query: @query, variables: %{id: published_article.id})
 
     assert json_response(conn, 200) == %{
@@ -28,6 +29,22 @@ defmodule FranklinWeb.ApiExperiences.CanGetArticleTest do
                  "body" => published_article.body,
                  "slug" => published_article.slug,
                  "publishedAt" => DateTime.to_iso8601(published_article.published_at)
+               }
+             }
+           }
+  end
+
+  test "returns an unpublished article by id", ~M{conn, unpublished_article} do
+    conn = get(conn, "/api", query: @query, variables: %{id: unpublished_article.id})
+
+    assert json_response(conn, 200) == %{
+             "data" => %{
+               "article" => %{
+                 "id" => unpublished_article.id,
+                 "title" => unpublished_article.title,
+                 "body" => unpublished_article.body,
+                 "slug" => unpublished_article.slug,
+                 "publishedAt" => nil
                }
              }
            }

--- a/test/franklin_web/api-experiences/can_get_articles_test.exs
+++ b/test/franklin_web/api-experiences/can_get_articles_test.exs
@@ -1,0 +1,39 @@
+defmodule FranklinWeb.ApiExperiences.CanGetArticlesTest do
+  use FranklinWeb.ConnCase
+
+  setup %{conn: conn} do
+    now = DateTime.utc_now()
+    yesterday = DateTime.utc_now() |> DateTime.add(-1, :day)
+    article1 = create_article!(%{published_at: now})
+    article2 = create_article!(%{published_at: yesterday})
+    article3 = create_article!(%{published_at: nil})
+    ~M{conn, article1, article2, article3, now, yesterday}
+  end
+
+  @query """
+  query {
+    articles {
+      id
+      publishedAt
+    }
+  }
+  """
+  test "returns a list of published articles", ~M{conn, article1, article2} do
+    conn = get(conn, "/api", query: @query)
+
+    assert json_response(conn, 200) == %{
+             "data" => %{
+               "articles" => [
+                 %{
+                   "id" => article1.id,
+                   "publishedAt" => DateTime.to_iso8601(article1.published_at)
+                 },
+                 %{
+                   "id" => article2.id,
+                   "publishedAt" => DateTime.to_iso8601(article2.published_at)
+                 }
+               ]
+             }
+           }
+  end
+end

--- a/test/franklin_web/api-experiences/can_get_articles_test.exs
+++ b/test/franklin_web/api-experiences/can_get_articles_test.exs
@@ -7,7 +7,7 @@ defmodule FranklinWeb.ApiExperiences.CanGetArticlesTest do
     article1 = create_article!(%{published_at: now})
     article2 = create_article!(%{published_at: yesterday})
     article3 = create_article!(%{published_at: nil})
-    ~M{conn, article1, article2, article3, now, yesterday}
+    ~M{conn, article1, article2, article3}
   end
 
   @query """
@@ -18,12 +18,16 @@ defmodule FranklinWeb.ApiExperiences.CanGetArticlesTest do
     }
   }
   """
-  test "returns a list of published articles", ~M{conn, article1, article2} do
+  test "returns a list of published articles", ~M{conn, article1, article2, article3} do
     conn = get(conn, "/api", query: @query)
 
     assert json_response(conn, 200) == %{
              "data" => %{
                "articles" => [
+                 %{
+                   "id" => article3.id,
+                   "publishedAt" => nil
+                 },
                  %{
                    "id" => article1.id,
                    "publishedAt" => DateTime.to_iso8601(article1.published_at)

--- a/test/franklin_web/api-experiences/can_get_upload_url_text.exs
+++ b/test/franklin_web/api-experiences/can_get_upload_url_text.exs
@@ -1,4 +1,4 @@
-defmodule FranklinWeb.ApiExperiences.CanGetUploadUrl do
+defmodule FranklinWeb.ApiExperiences.CanGetUploadUrlTest do
   use FranklinWeb.ConnCase
 
   @query """

--- a/test/franklin_web/api-experiences/can_get_upload_url_text.exs
+++ b/test/franklin_web/api-experiences/can_get_upload_url_text.exs
@@ -1,0 +1,21 @@
+defmodule FranklinWeb.ApiExperiences.CanGetUploadUrl do
+  use FranklinWeb.ConnCase
+
+  @query """
+  mutation {
+    generateUploadUrl(filename: "demo.jpg") {
+      url
+    }
+  }
+  """
+  test "returns an presigned url for the given filename", ~M{conn} do
+    conn = post(conn, "/api", query: @query)
+    assert response = json_response(conn, 200)
+    %{"data" => %{"generateUploadUrl" => %{"url" => url}}} = response
+
+    assert String.starts_with?(
+             url,
+             "http://localhost:9000/franklin-media/demo.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+           )
+  end
+end

--- a/test/support/arrange_article_helpers.ex
+++ b/test/support/arrange_article_helpers.ex
@@ -29,7 +29,10 @@ defmodule Franklin.ArrangeArticleHelpers do
     end)
   end
 
-  defp required_new_article_attributes(custom_values) do
+  @doc """
+  Returns a map of attributes that are required to create a new article.
+  """
+  def required_new_article_attributes(custom_values \\ %{}) do
     now = DateTime.utc_now()
 
     sample_markdown = """


### PR DESCRIPTION
Fixes #235

- [x] Add and test an endpoint to ask for all articles.
- [x] Add and test an endpoint to ask for an article by id.
- [x] Add and test and endpoint for article creation, verifiable via the above list request.
- [x] Add and test and endpoint for upload url creation.